### PR TITLE
Fix to fire Flask.before_request and Flask.after_request functions

### DIFF
--- a/example_rcfiles/konch_flask.py
+++ b/example_rcfiles/konch_flask.py
@@ -24,6 +24,8 @@ konch.config({
 ctx = app.test_request_context()
 def setup():
     ctx.push()
+    app.preprocess_request()
 
 def teardown():
+    app.process_response(app.response_class())
     ctx.pop()


### PR DESCRIPTION
According to the documentation for working with shell in Flask ([**link**](http://flask.pocoo.org/docs/1.0/shell/#firing-before-after-request)):
> By just creating a request context, you still don’t have run the code that is normally run before a request. This might result in your database being unavailable if you are connecting to the database in a before-request callback or the current user not being stored on the [g](http://flask.pocoo.org/docs/1.0/api/#flask.g) object etc.

This could be fixed by calling [`app.preprocess_request()`](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.preprocess_request) explicitly. Similarly, to trigger the [`after_request` functions](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.after_request), a trick is suggested like so: `app.process_response(app.response_class())`.