### PR TITLE
Read ptpython default configuration on initialization

### DIFF
--- a/konch.py
+++ b/konch.py
@@ -350,10 +350,11 @@ class PtPythonShell(Shell):
             raise ShellNotAvailableError("PtPython shell not available.")
         print(self.banner)
 
-        if not os.path.isfile(os.path.expanduser("~/.ptpython/config.py")):
-            run_config = None
+        if os.path.isfile(os.path.expanduser("~/.ptpython/config.py")):
+            embed(globals=self.context, vi_mode=self.ptpy_vi_mode, configure=run_config)
 
-        embed(globals=self.context, vi_mode=self.ptpy_vi_mode, configure=run_config)
+        else:
+            embed(globals=self.context, vi_mode=self.ptpy_vi_mode)
 
         return None
 

--- a/konch.py
+++ b/konch.py
@@ -345,11 +345,12 @@ class PtPythonShell(Shell):
 
     def start(self):
         try:
-            from ptpython.repl import embed
+            from ptpython.repl import embed, run_config
         except ImportError:
             raise ShellNotAvailableError("PtPython shell not available.")
         print(self.banner)
-        embed(globals=self.context, vi_mode=self.ptpy_vi_mode)
+        embed(globals=self.context, vi_mode=self.ptpy_vi_mode, configure=run_config)
+
         return None
 
 

--- a/konch.py
+++ b/konch.py
@@ -349,6 +349,10 @@ class PtPythonShell(Shell):
         except ImportError:
             raise ShellNotAvailableError("PtPython shell not available.")
         print(self.banner)
+
+        if not os.path.isfile(os.path.expanduser("~/.ptpython/config.py")):
+            run_config = None
+
         embed(globals=self.context, vi_mode=self.ptpy_vi_mode, configure=run_config)
 
         return None


### PR DESCRIPTION
Without this small change, ptpython, when launched with konch, will load with default settings rather than reading ~/.ptpython/config.py.

I've tested it and it works as expected with flask-konch, which of course uses konch itself.
In other words, "flask konch" now correctly loads ptpython with the settings in config.py, whereas before this change, it loaded ptpython with default settings.

