### PR TITLE
Only add encoding pragma on Python 2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Features:
   Thanks `@hartwork <https://github.com/hartwork>`_ for the suggestion.
 - Allow customizing the editor to use for ``konch edit`` via the
   ``KONCH_EDITOR`` environment variable.
+- ``konch init`` only adds the encoding pragma (``# -*- coding: utf-8 -*-\n``) on Python 2.
 
 Bug fixes:
 

--- a/konch.py
+++ b/konch.py
@@ -178,27 +178,30 @@ class AuthFile(object):
 CONFIG_FILE = ".konchrc"
 DEFAULT_CONFIG_FILE = os.path.join(_get_home_directory(), ".konchrc.default")
 
-INIT_TEMPLATE = """# -*- coding: utf-8 -*-
-# vi: set ft=python :
+INIT_TEMPLATE = """{}# vi: set ft=python :
 
 import konch
 
 # Available options:
-#   'context', 'banner', 'shell', 'prompt', 'output',
-#   'context_format', 'ipy_extensions', 'ipy_autoreload',
-#   'ipy_colors', 'ipy_highlighting_style'
-konch.config({
-    'context': {
-        'speak': konch.speak
-    }
-})
+#   "context", "banner", "shell", "prompt", "output",
+#   "context_format", "ipy_extensions", "ipy_autoreload",
+#   "ipy_colors", "ipy_highlighting_style"
+konch.config({{
+    "context": {{
+        "speak": konch.speak,
+    }}
+}})
+
 
 def setup():
     pass
 
+
 def teardown():
     pass
-"""
+""".format(
+    "# -*- coding: utf-8 -*-\n" if PY2 else ""
+)
 
 
 def _full_formatter(context):


### PR DESCRIPTION
Also, use black coding style in generated file.