### PR TITLE
Preview unauth'd files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 *********
 
+3.1.0 (unreleased)
+------------------
+
+- Show preview of unauthorized files.
+
 3.0.0.post0 (2018-12-22)
 ------------------------
 

--- a/konch.py
+++ b/konch.py
@@ -815,9 +815,17 @@ def use_file(filename):
                 )
                 sys.exit(1)
             except KonchrcNotAuthorizedError:
+                print('"{}" is blocked.\n'.format(config_file), file=sys.stderr)
+                print("*" * 46, file=sys.stderr)
+                print(file=sys.stderr)
+                with codecs.open(config_file, "r", "utf-8") as fp:
+                    for line in fp:
+                        print(line, end="", file=sys.stderr)
+                print(file=sys.stderr)
+                print("*" * 46, file=sys.stderr)
+                print(file=sys.stderr)
                 print(
-                    '"{}" is blocked. Verify the file\'s '
-                    "contents and run `konch allow` to approve it.".format(config_file),
+                    "Verify the file's contents and run `konch allow` to approve it.",
                     file=sys.stderr,
                 )
                 sys.exit(1)


### PR DESCRIPTION
Example:

```
konch ❯ konch
"/Users/sloria/projects/python-projects/konch/.konchrc" is blocked.

**********************************************

# -*- coding: utf-8 -*-
# vi: set ft=python :
import os

import konch
from test_konch import env
import IPython
import bpython
import ptpython

konch.config(
    {
        "context": {
            "konch": konch,
            "testenv": env,
            "os": os,
            "IPython": IPython,
            "bpython": bpython,
            "ptpython": ptpython,
        },
        "prompt": "[konch] >>> ",
        "ipy_colors": "linux",
        "ipy_autoreload": True,
        "ptpy_vi_mode": True,
        "context_format": "full",
    }
)

**********************************************

Verify the file's contents and run `konch allow` to approve it.

```