### PR TITLE
Add `trust` parameter to use_file

### DIFF
--- a/.konchrc
+++ b/.konchrc
@@ -26,4 +26,4 @@ konch.config(
 )
 
 if Path(".konchrc.local").exists():
-    konch.use_file(".konchrc.local")
+    konch.use_file(".konchrc.local", trust=True)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Features:
 - ``konch edit`` may be passed a filename to edit.
 - ``konch.main`` accepts an ``argv`` argument.
 - Add ANSI coloring and improve messaging (:issue:`67`).
+- Add ``trust`` parameter to ``konch.use_file()``.
 
 Other changes:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -339,13 +339,20 @@ Then add the following to your ``.konchrc``:
     # konch.config(...)
 
     if Path(".konchrc.local").exists():
-        konch.use_file(".konchrc.local")
+        konch.use_file(".konchrc.local", trust=True)
 
 
 .. note::
 
     The ``context`` in ``.konchrc.local`` will be merged
     with the context in ``.konchrc``.
+
+.. note::
+
+   Passing ``trust=True`` allows ``.konchrc.local`` to be
+   edited without requiring approval.
+   **This is safe if (and only if) .konchrc.local is not
+   added to source control.**
 
 
 Programmatic Usage


### PR DESCRIPTION
Useful when using .konchrc.local files.
Also, add unit tests for AuthFile.