### PR TITLE
Pass path string to run_config

### DIFF
--- a/konch.py
+++ b/konch.py
@@ -516,7 +516,7 @@ class PtPythonShell(Shell):
         def configure(repl):
             path = config_dir / "config.py"
             if path.exists():
-                run_config(repl, path)
+                run_config(repl, str(path))
 
         embed(
             globals=self.context,
@@ -560,7 +560,7 @@ class PtIPythonShell(PtPythonShell):
         def configure(repl):
             path = config_dir / "config.py"
             if path.exists():
-                run_config(repl, path)
+                run_config(repl, str(path))
 
         # Startup path
         startup_paths = []


### PR DESCRIPTION
https://github.com/prompt-toolkit/ptpython/blob/master/ptpython/repl.py#L252

It seems like ptpython wants a string of the configuration path passed to the `run_config` function. Without this change locally, it fails the assertion linked above. With the changes in place, I'm able to run ptipython just fine as my konch shell.

Cheers for the project!