### PR TITLE
Prevent error when objects have no __name__.

### DIFF
--- a/konch.py
+++ b/konch.py
@@ -1145,6 +1145,20 @@ def parse_args(argv: typing.Optional[typing.Sequence] = None) -> typing.Dict[str
     return docopt(__doc__, argv=argv, version=__version__)
 
 
+def get_config(mod: typing.Optional[types.ModuleType]) -> Config:
+    """Get _cfg object from loaded module."""
+    try:
+        k_atr = "konch"
+        if hasattr(mod, k_atr):
+            k = getattr(mod, k_atr)
+            c_atr = "_cfg"
+            if hasattr(k, c_atr):
+                config = getattr(k, c_atr)
+    except AttributeError:
+        config = _cfg
+    return config
+
+
 def main(argv: typing.Optional[typing.Sequence] = None) -> typing.NoReturn:
     """Main entry point for the konch CLI."""
     args = parse_args(argv)
@@ -1169,6 +1183,7 @@ def main(argv: typing.Optional[typing.Sequence] = None) -> typing.NoReturn:
             deny_config(config_file)
 
     mod = use_file(Path(args["--file"]) if args["--file"] else None)
+    _cfg = get_config(mod)
     if hasattr(mod, "setup"):
         mod.setup()  # type: ignore
 

--- a/konch.py
+++ b/konch.py
@@ -282,11 +282,20 @@ def make_banner(
     return out
 
 
+def get_obj_name(obj: typing.Any) -> str:
+    """Try to get object __name__ attribute, otherwise return blank."""
+    try:
+        name = obj.__name__
+    except AttributeError:
+        name = ""
+    return name
+
+
 def context_list2dict(context_list: typing.Sequence[typing.Any]) -> Context:
     """Converts a list of objects (functions, classes, or modules) to a
     dictionary mapping the object names to the objects.
     """
-    return {obj.__name__.split(".")[-1]: obj for obj in context_list}
+    return {get_obj_name(obj).split(".")[-1]: obj for obj in context_list}
 
 
 def _relpath(p: Path) -> Path:

--- a/konch.py
+++ b/konch.py
@@ -287,7 +287,7 @@ def get_obj_name(obj: typing.Any) -> str:
     try:
         name = obj.__name__
     except AttributeError:
-        name = ""
+        name = obj.__hash__
     return name
 
 


### PR DESCRIPTION
Created function get_obj_name to try to get the __name__ attribute, otherwise return empty string.