### PR TITLE
Prevent blank context, test added.

### DIFF
--- a/konch.py
+++ b/konch.py
@@ -1177,7 +1177,7 @@ def get_config_from_module(mod: typing.Optional[types.ModuleType]) -> Config:
             if obj in config["context"].values():
                 ctx[obj_name] = obj
             else:
-                logger.warning(f"Object not in context: {obj}")
+                logger.info(f"Object not in context: {obj}")
         except UnboundLocalError:
             ctx[obj_name] = obj
     logger.debug(f"Getting context from module: {ctx}")

--- a/konch.py
+++ b/konch.py
@@ -1136,6 +1136,20 @@ def parse_args(argv: typing.Optional[typing.Sequence] = None) -> typing.Dict[str
     return docopt(__doc__, argv=argv, version=__version__)
 
 
+def get_config(mod: typing.Optional[types.ModuleType]) -> Config:
+    """Get _cfg object from loaded module."""
+    try:
+        k_atr = "konch"
+        if hasattr(mod, k_atr):
+            k = getattr(mod, k_atr)
+            c_atr = "_cfg"
+            if hasattr(k, c_atr):
+                config = getattr(k, c_atr)
+    except AttributeError:
+        config = _cfg
+    return config
+
+
 def main(argv: typing.Optional[typing.Sequence] = None) -> typing.NoReturn:
     """Main entry point for the konch CLI."""
     args = parse_args(argv)
@@ -1160,6 +1174,7 @@ def main(argv: typing.Optional[typing.Sequence] = None) -> typing.NoReturn:
             deny_config(config_file)
 
     mod = use_file(Path(args["--file"]) if args["--file"] else None)
+    _cfg = get_config(mod)
     if hasattr(mod, "setup"):
         mod.setup()  # type: ignore
 

--- a/test_konch.py
+++ b/test_konch.py
@@ -396,6 +396,12 @@ def test_version(env):
     assert konch.__version__ in res.stdout
 
 
+def test_nonblank_context(env):
+    env.run("konch", "init")
+    res = env.run("python", "-m", "konch", expect_stderr=True)
+    assert "<module 'sys'" in res.stdout
+
+
 TEST_CONFIG_WITH_NAMES = """
 import konch
 

--- a/test_konch.py
+++ b/test_konch.py
@@ -178,6 +178,16 @@ def test_config_update_context_converts_list():
     assert config["context"] == {"math": math}
 
 
+def test_config_blank_name():
+    class FakeModule:
+        import math
+
+        del math.__name__
+
+    config = konch.get_config_from_module(FakeModule)
+    assert "math" in config["context"].keys()
+
+
 def test_config_shallow_merges_context():
     config = konch.Config()
     config.update({"context": {"foo": 42}, "banner": "bar"})


### PR DESCRIPTION
Addresses #99. Shell starts with empty context when konch is launched via `python konch.py` or `python -m konch`.
New test for issue added.
It was a challenge to write this in a way that passed mypy, which is why the new get_config function may seem convoluted, although it is possible I am just missing a simpler solution.