### PR TITLE
Ensure config is always loaded.

### DIFF
--- a/konch.py
+++ b/konch.py
@@ -946,12 +946,31 @@ def use_file(
         except UnboundLocalError:  # File not found
             pass
         else:
+            __ensure_global_cfg_loaded(mod)
             return mod
     if not config_file:
         print_warning("No konch config file found.")
     else:
         print_warning(f'"{config_file}" not found.')
     return None
+
+
+def __ensure_global_cfg_loaded(mod: typing.Union[types.ModuleType, None]) -> None:
+    try:
+        if (
+            globals()["_cfg"] is None
+            or globals()["_cfg"] == {}
+            or globals()["_cfg"] == Config()
+        ):
+            raise UnboundLocalError
+    except UnboundLocalError:
+        k_atr = "konch"
+        if hasattr(mod, k_atr):
+            k = getattr(mod, k_atr)
+            c_atr = "_cfg"
+            if hasattr(k, c_atr):
+                _cfg = getattr(k, c_atr)
+                globals()["_cfg"] = _cfg
 
 
 def resolve_path(filename: Path) -> typing.Union[Path, None]:

--- a/konch.py
+++ b/konch.py
@@ -956,6 +956,7 @@ def use_file(
 
 
 def __ensure_global_cfg_loaded(mod: typing.Union[types.ModuleType, None]) -> None:
+    """Load global config if not already loaded."""
     try:
         if (
             globals()["_cfg"] is None

--- a/test_konch.py
+++ b/test_konch.py
@@ -396,6 +396,12 @@ def test_version(env):
     assert konch.__version__ in res.stdout
 
 
+def test_nonblank_context(env):
+    env.run("konch", "init")
+    res = env.run("python", "-m", "konch", expect_stderr=True)
+    assert "<module 'sys'" in res.stdout
+
+
 TEST_CONFIG_WITH_NAMES = """
 import konch
 

--- a/test_konch.py
+++ b/test_konch.py
@@ -396,7 +396,8 @@ def test_version(env):
     assert konch.__version__ in res.stdout
 
 
-def test_nonblank_context(env):
+def test_nonblank_config(env):
+    """Ensure config is loaded when launched via python command."""
     env.run("konch", "init")
     res = env.run("python", "-m", "konch", expect_stderr=True)
     assert "<module 'sys'" in res.stdout


### PR DESCRIPTION
Correct issue #99, config is not loaded when launched via `python konch.py` or `python -m konch`.  Includes test for this issue.