### PR TITLE
Allow setting custom Prompts class for IPython; fix `output` bug for IPython

### DIFF
--- a/konch.py
+++ b/konch.py
@@ -400,8 +400,10 @@ def configure_ipython_prompt(
                 if isinstance(output, (str, bytes)):
                     return [(Token.OutPrompt, output)]
                 else:
-                    return prompt
+                    return output
 
+        if isinstance(prompt, IPython.terminal.prompts.Prompts):
+            CustomPrompt = prompt
         config.TerminalInteractiveShell.prompts_class = CustomPrompt
     else:
         prompt_config = config.PromptManager


### PR DESCRIPTION
Hi! I was hoping you might take a quick look at this PR. It:

- Allows setting a custom IPython.terminal.prompts.Prompts class to `prompt` in order to support more complex overrides of IPython shell behavior, e.g., including the current line number (`self.shell.execution_count`)
- Fixes a bug where for IPython shells `prompt` was being used vs. the `output` config param