### PR TITLE
Follow XDG standard in config file discovery

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,15 @@
 Changelog
 *********
 
-(unreleased)
-------------
+4.3.0 (unreleased)
+------------------
+
+Features:
+
+- Follow XDG standard in config file discovery (:issue:`177`).
+  Thanks :user:`rpdelaney` for PR and the suggestion.
+
+Other changes:
 
 - Test against Python 3.8 and 3.9.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==3.2.1
+sphinx==3.3.0
 sphinx-issues==1.2.0

--- a/konch.py
+++ b/konch.py
@@ -880,18 +880,13 @@ def __ensure_directory_in_path(filename: Path) -> None:
 
 
 CONFIG_FILE = Path(".konchrc")
-DEFAULT_CONFIG_PATHS = {
-    "xdg": (
-        Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
-        / "konchrc.default"
-    ),
-    "home": Path.home() / ".konchrc.default",
-}
-for _, DEFAULT_CONFIG_FILE in DEFAULT_CONFIG_PATHS.items():
+for DEFAULT_CONFIG_FILE in (
+    Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    / "konchrc.default",
+    Path.home() / ".konchrc.default",
+):
     if DEFAULT_CONFIG_FILE.exists():
         break
-else:
-    DEFAULT_CONFIG_FILE = DEFAULT_CONFIG_PATHS["xdg"]
 
 SEPARATOR = f"\n{'*' * 46}\n"
 

--- a/konch.py
+++ b/konch.py
@@ -880,7 +880,19 @@ def __ensure_directory_in_path(filename: Path) -> None:
 
 
 CONFIG_FILE = Path(".konchrc")
-DEFAULT_CONFIG_FILE = Path.home() / ".konchrc.default"
+DEFAULT_CONFIG_PATHS = {
+    "xdg": (
+        Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+        / "konchrc.default"
+    ),
+    "home": Path.home() / ".konchrc.default"
+}
+for _, DEFAULT_CONFIG_FILE in DEFAULT_CONFIG_PATHS.items():
+    if DEFAULT_CONFIG_FILE.exists():
+        break
+else:
+    DEFAULT_CONFIG_FILE = DEFAULT_CONFIG_PATHS["xdg"]
+
 SEPARATOR = f"\n{'*' * 46}\n"
 
 
@@ -1057,7 +1069,7 @@ def init_config(config_file: Path) -> typing.NoReturn:
         print(INIT_TEMPLATE, end="")
         print(SEPARATOR)
         init_template = INIT_TEMPLATE
-        if DEFAULT_CONFIG_FILE.exists():  # use ~/.konchrc.default if it exists
+        if DEFAULT_CONFIG_FILE.exists():
             with Path(DEFAULT_CONFIG_FILE).open("r") as fp:
                 init_template = fp.read()
         with Path(config_file).open("w") as fp:

--- a/konch.py
+++ b/konch.py
@@ -885,7 +885,7 @@ DEFAULT_CONFIG_PATHS = {
         Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
         / "konchrc.default"
     ),
-    "home": Path.home() / ".konchrc.default"
+    "home": Path.home() / ".konchrc.default",
 }
 for _, DEFAULT_CONFIG_FILE in DEFAULT_CONFIG_PATHS.items():
     if DEFAULT_CONFIG_FILE.exists():

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands = pytest {posargs}
 [testenv:lint]
 deps = pre-commit~=2.3
 skip_install = true
-commands = pre-commit run --all-files
+commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:docs]
 deps = -rdocs/requirements.txt


### PR DESCRIPTION
Closes #177

If you'd like tests specific to this new logic, it shouldn't be a problem. I'll just have to capture this in a function.

It seems `konch init` does create a config file, so I put the `else:` in to ensure it goes in the right place.