### PR TITLE
Remove setup.py command and documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -379,7 +379,6 @@ To use a config file:
 Get command-line arguments using ``konch.parse_args()``. ``konch`` uses `docopt`_ for arguments parsing.
 
 
-
 .. code-block:: python
 
     import konch
@@ -402,66 +401,6 @@ You can also use shell objects directly:
 
     my_shell = konch.AutoShell(context={"foo": 42}, banner="My foo shell")
     my_shell.start()
-
-
-Integrating with setuptools / ``python setup.py shell``
-=======================================================
-
-You can integrate konch into your setuptools-based project using
-the following ``Command`` class.
-
-.. code-block:: python
-
-    # setup.py
-    import shlex
-    from setuptools import Command
-
-
-    class Shell(Command):
-        user_options = [
-            ("name=", "n", "Named config to use."),
-            ("shell=", "s", "Shell to use."),
-            ("file=", "f", "File path of konch config file to execute."),
-        ]
-
-        def initialize_options(self):
-            self.name = None
-            self.shell = None
-            self.file = None
-
-        def finalize_options(self):
-            pass
-
-        def run(self):
-            import konch
-
-            argv = []
-            for each in ("name", "shell", "file"):
-                opt = getattr(self, each)
-                if opt:
-                    argv.append(f"--{each}={opt}")
-            konch.main(argv)
-
-
-    setup(
-        # ...,
-        cmdclass={"shell": Shell}
-    )
-
-
-You can now run:
-
-.. code-block:: bash
-
-   $ python setup.py shell
-
-
-You can also pass a string of arguments:
-
-
-.. code-block:: bash
- 
-   $ python setup.py shell -a "--shell ipy"
 
 ..
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import re
 
-from setuptools import Command, setup
+from setuptools import setup
 
 EXTRAS_REQUIRE = {
     "tests": ["pytest", "scripttest==1.3", "ipython", "bpython"],
@@ -19,32 +19,6 @@ EXTRAS_REQUIRE["dev"] = (
     EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["ptpython", "tox"]
 )
 PYTHON_REQUIRES = ">=3.8"
-
-
-class Shell(Command):
-    user_options = [
-        ("name=", "n", "Named config to use."),
-        ("shell=", "s", "Shell to use."),
-        ("file=", "f", "File path of konch config file to execute."),
-    ]
-
-    def initialize_options(self):
-        self.name = None
-        self.shell = None
-        self.file = None
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        import konch
-
-        argv = []
-        for each in ("name", "shell", "file"):
-            opt = getattr(self, each)
-            if opt:
-                argv.append(f"--{each}={opt}")
-        konch.main(argv)
 
 
 def find_version(fname):
@@ -82,7 +56,6 @@ setup(
     author_email="sloria1@gmail.com",
     url="https://github.com/sloria/konch",
     install_requires=[],
-    cmdclass={"shell": Shell},
     extras_require=EXTRAS_REQUIRE,
     python_requires=PYTHON_REQUIRES,
     license="MIT",


### PR DESCRIPTION
setup.py commands are deprecated 

https://packaging.python.org/en/latest/guides/modernize-setup-py-project/#should-setup-py-be-deleted