### PR TITLE
Fixes ptpython/ptipython config and history (#278)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 *********
 
+unreleased
+----------
+
+Bug fixes:
+
+* Load ptpython config and history from new location as of ptpython 3.0.0 (:issue:`278`).
+  Thanks :user:`notdaniel` for the PR.
+
 6.0.0 (2024-11-22)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,6 @@ Configures your Python shell
 
 - **Automatically import** any object upon startup
 - **Simple**, per-project configuration in a single file (it's just Python code)
-- **No external dependencies**
 - Uses **IPython**, **BPython**, or **ptpython** if available, and falls back to built-in interpreter
 - Automatically load **IPython extensions**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,6 @@ About
 
 - **Automatically import** any object upon startup
 - **Simple**, per-project configuration in a single file (it's just Python code)
-- **No external dependencies**
 - Uses **IPython**, **BPython**, or **ptpython** if available, and falls back to built-in interpreter
 - Automatically load **IPython extensions**
 
@@ -48,7 +47,7 @@ Install/Upgrade
 
     $ pip install -U konch
 
-Supports Python>=3.9. There are no external dependencies.
+Supports Python>=3.9.
 
 Usage
 =====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
   "Topic :: System :: Shells",
 ]
 requires-python = ">=3.9"
+dependencies = ["platformdirs>=4.3.7"]
 
 [project.scripts]
 konch = "konch:main"

--- a/src/konch/__init__.py
+++ b/src/konch/__init__.py
@@ -511,7 +511,28 @@ class PtPythonShell(Shell):
             raise ShellNotAvailableError("PtPython shell not available.") from error
         print(self.banner)
 
-        config_dir = Path("~/.ptpython/").expanduser()
+        # Determine config directory
+        config_dirs = [
+            Path(os.environ.get("XDG_CONFIG_HOME", "~/.config")) / "ptpython",
+            Path("~/Library/Application Support/ptpython"),
+            Path("~/.ptpython"),
+        ]
+        # Use the first config directory that exists
+        config_dir = next(
+            (d for d in (p.expanduser() for p in config_dirs) if d.exists()), None
+        )
+
+        # Determine history directory
+        history_dirs = [
+            Path(os.environ.get("XDG_DATA_HOME", "~/.local/share")) / "ptpython",
+            Path("~/Library/Application Support/ptpython"),
+            Path("~/.ptpython"),
+        ]
+        # Use the first history directory that exists
+        history_dir = next(
+            (d for d in (p.expanduser() for p in history_dirs) if d.exists()), None
+        )
+        history_filename = str(history_dir / "history") if history_dir else None
 
         # Startup path
         startup_paths = []
@@ -520,13 +541,14 @@ class PtPythonShell(Shell):
 
         # Apply config file
         def configure(repl):
-            path = config_dir / "config.py"
-            if path.exists():
-                run_config(repl, str(path))
+            if config_dir is not None:
+                path = config_dir / "config.py"
+                if path.exists():
+                    run_config(repl, str(path))
 
         embed(
             globals=self.context,
-            history_filename=str(config_dir / "history"),
+            history_filename=history_filename,
             vi_mode=self.ptpy_vi_mode,
             startup_paths=startup_paths,
             configure=configure,
@@ -559,13 +581,35 @@ class PtIPythonShell(PtPythonShell):
         except ImportError as error:
             raise ShellNotAvailableError("PtIPython shell not available.") from error
 
-        config_dir = Path("~/.ptpython/").expanduser()
+        # Determine config directory
+        config_dirs = [
+            Path(os.environ.get("XDG_CONFIG_HOME", "~/.config")) / "ptpython",
+            Path("~/Library/Application Support/ptpython"),
+            Path("~/.ptpython"),
+        ]
+        # Use the first config directory that exists
+        config_dir = next(
+            (d for d in (p.expanduser() for p in config_dirs) if d.exists()), None
+        )
+
+        # Determine history directory
+        history_dirs = [
+            Path(os.environ.get("XDG_DATA_HOME", "~/.local/share")) / "ptpython",
+            Path("~/Library/Application Support/ptpython"),
+            Path("~/.ptpython"),
+        ]
+        # Use the first history directory that exists
+        history_dir = next(
+            (d for d in (p.expanduser() for p in history_dirs) if d.exists()), None
+        )
+        history_filename = str(history_dir / "history") if history_dir else None
 
         # Apply config file
         def configure(repl):
-            path = config_dir / "config.py"
-            if path.exists():
-                run_config(repl, str(path))
+            if config_dir is not None:
+                path = config_dir / "config.py"
+                if path.exists():
+                    run_config(repl, str(path))
 
         # Startup path
         startup_paths = []
@@ -588,7 +632,7 @@ class PtIPythonShell(PtPythonShell):
         embed(
             config=ipy_config,
             configure=configure,
-            history_filename=config_dir / "history",
+            history_filename=history_filename,
             user_ns=self.context,
             header=self.banner,
             vi_mode=self.ptpy_vi_mode,


### PR DESCRIPTION
This fixes the ptpython/ptipython configuration issue from #278. It will now iterate through a list of all possible config directory locations in order of priority and use the first one it finds, if one exists.

Additionally, very similar logic is now applied to the history filename location to address these 2 bugs:

1. On linux, ptpython no longer keeps the history file inside the config directory, but in a different place entirely. Fixing the config directory issue does *not* make history work properly.

2. Previously, a `history_filename` was being passed to `embed` whether it existed or not. If it doesn't exist, ptpython will try to create it and write to it, but unfortunately it only checks whether the *file* exists, and *not* whether its parent directories do. Giving it a `history_filename` that doesn't exist is fine as long as its parent directory does, but if not, it throws an exception.

It now looks for the history directory in the correct places, and if it cannot find one, it passes `history_filename=None` to `embed`.
